### PR TITLE
Bugfix: VideoReader has no attribute 'frames'

### DIFF
--- a/src/videoreader.py
+++ b/src/videoreader.py
@@ -70,7 +70,7 @@ class VideoReader:
         return f"{self._filename} with {len(self)} frames of size {self.frame_shape} at {self.frame_rate:1.2f} fps"
 
     def __iter__(self):
-        return self.frames(start=0, stop=None, step=1)
+        return self[:]
 
     def __enter__(self):
         return self


### PR DESCRIPTION
Hi,

Thanks for this useful library!  The napari plugin is quite cool!  
Small fix, VideoReader.__iter__() referenced a nonexistent 'frames' attribute.  Converting it to a __getitem__() call should fix it.

Best wishes,

Nick